### PR TITLE
Wrong Jenkins API call

### DIFF
--- a/src/JobHelper.groovy
+++ b/src/JobHelper.groovy
@@ -35,7 +35,7 @@ class JobHelper {
     public static boolean jobIsRunning(String jobName) {
         return Jenkins.getInstance().getAllItems()
             .findAll { job -> 
-                job.fullName == jobName && (job.isBuilding() || job.isQueued())
+                job.fullName == jobName && (job.isBuilding() || job.isInQueue())
             }.size() > 0;
     }
 }


### PR DESCRIPTION
* isQueued() is not a valid jenkins javadoc method. The correct function is isInQueue()

Signed-off-by: Morgan Davies <morgan.davies@ibm.com>