### PR TITLE
getInstance is deprecated

### DIFF
--- a/src/JobHelper.groovy
+++ b/src/JobHelper.groovy
@@ -33,7 +33,7 @@ class JobHelper {
     * @return
     */
     public static boolean jobIsRunning(String jobName) {
-        return Jenkins.getInstance().getAllItems()
+        return Jenkins.get().getAllItems()
             .findAll { job -> 
                 job.fullName == jobName && (job.isBuilding() || job.isQueued())
             }.size() > 0;
@@ -46,13 +46,15 @@ class JobHelper {
     */
     public static String getJobFolder(String jobName) {
         try {
-            Jenkins.getInstance().getAllItems().findAll { job -> 
-                if (job.fullName == jobName) {
-                    return job.fullProjectName
-                }
-            }
+          def foundJob
+          Jenkins.get().getAllItems().each { job -> 
+              if (job.fullName == jobName) {
+                  foundJob = job.getFullDisplayName()
+              }
+          }
+          return foundJob
         } catch (Exception e) {
-            throw new RuntimeException("${e.getMessage()}")
+          throw new RuntimeException("${e.getMessage()}")
         }
     }
 


### PR DESCRIPTION
* getInstance is deprecated, defaulting to the standard get() function instead
* Revamped getJobFolder() to use the newer getFullDisplayName() function over fullProjectName

Signed-off-by: Morgan Davies <morgan.davies@ibm.com>